### PR TITLE
Match prior element to string behavior

### DIFF
--- a/tablepyxl/style.py
+++ b/tablepyxl/style.py
@@ -228,7 +228,10 @@ def _element_to_string(el):
     for x in children:
         string += '\n' + element_to_string(x)
 
-    return el.text.strip() + string + '\n' + el.tail.strip()
+    text = el.text.strip() if el.text else ''
+    tail = el.tail.strip() if el.tail else ''
+
+    return text + string + '\n' + tail
 
 
 class TableCell(Element):

--- a/tablepyxl/style.py
+++ b/tablepyxl/style.py
@@ -224,7 +224,7 @@ def _element_to_string(el):
     string = ''
 
     for x in el.iterchildren():
-        string += '\n' + element_to_string(x)
+        string += '\n' + _element_to_string(x)
 
     text = el.text.strip() if el.text else ''
     tail = el.tail.strip() if el.tail else ''

--- a/tablepyxl/style.py
+++ b/tablepyxl/style.py
@@ -216,6 +216,21 @@ class TableRow(Element):
         self.cells = [TableCell(cell, parent=self) for cell in tr.findall('th') + tr.findall('td')]
 
 
+def element_to_string(el):
+    return _element_to_string(el).strip()
+
+
+def _element_to_string(el):
+    children = el.getchildren()
+
+    string = ''
+
+    for x in children:
+        string += '\n' + element_to_string(x)
+
+    return el.text.strip() + string + '\n' + el.tail.strip()
+
+
 class TableCell(Element):
     """
     This class maps to the `<td>` element of the html table.
@@ -225,7 +240,7 @@ class TableCell(Element):
 
     def __init__(self, cell, parent=None):
         super(TableCell, self).__init__(cell, parent=parent)
-        self.value = cell.text.strip() if cell.text else ''
+        self.value = element_to_string(cell)
         self.number_format = self.get_number_format()
 
     def data_type(self):

--- a/tablepyxl/style.py
+++ b/tablepyxl/style.py
@@ -221,11 +221,9 @@ def element_to_string(el):
 
 
 def _element_to_string(el):
-    children = el.getchildren()
-
     string = ''
 
-    for x in children:
+    for x in el.iterchildren():
         string += '\n' + element_to_string(x)
 
     text = el.text.strip() if el.text else ''

--- a/tests/test_tablepyxl.py
+++ b/tests/test_tablepyxl.py
@@ -66,6 +66,17 @@ table_widths = "<table name='width table'><thead></thead> " \
                "</tbody> " \
                "</table>"
 
+table_whitespace = """
+    <table name='whitespace table'>
+        <thead></thead>"
+        <tbody>
+            <tr>
+                <td>   a  bc  <inn1>  d  ef  </inn1>  g  hi   <inn2>   j  k  <inn3>  l  m  </inn3>  n  o  </inn2>  p  </td>
+            </tr>
+        </tbody>
+    </table>
+"""
+
 
 class TestTablepyxl(unittest.TestCase):
     """
@@ -131,6 +142,13 @@ class TestTablepyxl(unittest.TestCase):
         insert_table_at_cell(table[0], cell)
 
         self.assertEqual(ws['B2'].value, 'A cell')
+
+    def test_element_whitespace(self):
+        doc = table_whitespace
+        wb = document_to_workbook(doc)
+        sheet = wb['whitespace table']
+
+        self.assertEqual(sheet['A1'].value, 'a  bc\nd  ef\ng  hi\nj  k\nl  m\nn  o\np')
 
 
 class TestStyle(unittest.TestCase):

--- a/tests/test_tablepyxl.py
+++ b/tests/test_tablepyxl.py
@@ -66,16 +66,14 @@ table_widths = "<table name='width table'><thead></thead> " \
                "</tbody> " \
                "</table>"
 
-table_whitespace = """
-    <table name='whitespace table'>
-        <thead></thead>"
-        <tbody>
-            <tr>
-                <td>   a  bc  <inn1>  d  ef  </inn1>  g  hi   <inn2>   j  k  <inn3>  l  m  </inn3>  n  o  </inn2>  p  </td>
-            </tr>
-        </tbody>
-    </table>
-"""
+table_whitespace = "<table name='whitespace table'>" \
+                   "<thead></thead>" \
+                   "<tbody>" \
+                   "<tr>" \
+                   "<td>   a  bc  <inn1>  d  ef  </inn1>  g  hi   <inn2>   j  k  <inn3>  l  m  </inn3>  n  o  </inn2>  p  </td>" \
+                   "</tr>" \
+                   "</tbody>" \
+                   "</table>"
 
 
 class TestTablepyxl(unittest.TestCase):


### PR DESCRIPTION
BeautifulSoup's get_text() method, specifically get_text(separator="\n", strip=True), turned html elements into text differently than lxml's cell.text, which only yields the text in that specific element, not its children.

Emulate that same behavior so we produce the same results as before.