### PR TITLE
HTML comments should not be included in worksheets

### DIFF
--- a/tablepyxl/tablepyxl.py
+++ b/tablepyxl/tablepyxl.py
@@ -16,6 +16,9 @@ def string_to_int(s):
 
 def get_Tables(doc):
     tree = html.fromstring(doc)
+    comments = tree.xpath('//comment()')
+    for comment in comments:
+        comment.drop_tag()
     return [Table(table) for table in tree.xpath('//table')]
 
 

--- a/tests/test_tablepyxl.py
+++ b/tests/test_tablepyxl.py
@@ -128,7 +128,7 @@ class TestTablepyxl(unittest.TestCase):
     def test_comments(self):
         wb = document_to_workbook(table_comment)
         sheet = wb['comment table']
-        self.assertNotEqual(sheet['A1'].value, 'this is a html comment')
+        self.assertNotIn('this is a html comment', sheet['A1'].value)
         self.assertEqual(sheet['B1'].value, 'this is not a html comment')
 
     def test_spans(self):

--- a/tests/test_tablepyxl.py
+++ b/tests/test_tablepyxl.py
@@ -75,6 +75,13 @@ table_whitespace = "<table name='whitespace table'>" \
                    "</tbody>" \
                    "</table>"
 
+table_comment = "<table name='comment table'>" \
+                "<tr>" \
+                "<td><!-- this is a html comment --></td>" \
+                "<td>this is not a html comment</td>" \
+                "</tr>" \
+                "</table>"
+
 
 class TestTablepyxl(unittest.TestCase):
     """
@@ -117,6 +124,12 @@ class TestTablepyxl(unittest.TestCase):
         # Add another sheet to the existing workbook
         wb = document_to_workbook(table_three, wb=wb)
         self.assertEqual(wb.sheetnames, ['simple table', 'second table', 'Another simple table'])
+
+    def test_comments(self):
+        wb = document_to_workbook(table_comment)
+        sheet = wb['comment table']
+        self.assertNotEqual(sheet['A1'].value, 'this is a html comment')
+        self.assertEqual(sheet['B1'].value, 'this is not a html comment')
 
     def test_spans(self):
         doc = table_span


### PR DESCRIPTION
Switch from BeautifulSoup resulted in HTML comments being printed in documents. 