### PR TITLE
fix bug when this is a rowspan in table str

### DIFF
--- a/tablepyxl/tablepyxl.py
+++ b/tablepyxl/tablepyxl.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from lxml import html
+from openpyxl.cell.cell import MergedCell
 from openpyxl import Workbook
 from openpyxl.utils import get_column_letter
 from premailer import Premailer
@@ -37,6 +38,10 @@ def write_rows(worksheet, elem, row, column=1):
                 worksheet.merge_cells(start_row=row, start_column=column,
                                       end_row=row + rowspan - 1, end_column=column + colspan - 1)
             cell = worksheet.cell(row=row, column=column)
+            while isinstance(cell, MergedCell):
+                column +=1
+                cell = worksheet.cell(row=row, column=column)
+
             cell.value = table_cell.value
             table_cell.format(cell)
             min_width = table_cell.get_dimension('min-width')


### PR DESCRIPTION
when I write a html table string to excel like
```sh
"<html><body><table><thead><tr><td rowspan=\"3\"><b>1-1</b></td><td colspan=\"4\">2-5</td></td></tr><tr><td>2</td><td>3</td><td>4</td><td>5</td></tr></table></body></html>"
```
I will meet the error like this

![image](https://user-images.githubusercontent.com/12406017/121122039-4b885a00-c853-11eb-9316-2af4e414deba.png)

when add follow code to line 40 in  /tablepyxl/tablepyxl.py, it work

```python
  while isinstance(cell,openpyxl.cell.cell.MergedCell):
        column +=1
        cell = worksheet.cell(row=row, column=column)
```